### PR TITLE
Use phpdbg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,6 @@
 # Travis Setup
 #
 
-# use ubuntu trusty for newer version of nodejs, used for JS testing
-dist: trusty
-
-# faster builds on new travis setup not using sudo
-# temporary disable, see https://github.com/travis-ci/travis-ci/issues/6842
-#sudo: false
-sudo: required
-
 # build only on master branches
 # commented as this prevents people from running builds on their forks:
 # https://github.com/yiisoft/yii2/commit/bd87be990fa238c6d5e326d0a171f38d02dc253a
@@ -86,9 +78,6 @@ install:
       tests/data/travis/memcache-setup.sh
       tests/data/travis/imagick-setup.sh
     fi
-
-  # Needed for FileCacheTest
-  - sudo useradd $TRAVIS_SECOND_USER --gid $(id -g) -M
 
 before_script:
   # show some versions and env information

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,6 @@ before_script:
   - mysql_upgrade
   - travis_retry mysql -e 'CREATE DATABASE `yiitest`;';
   - mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';";
-  - mysql -e "CREATE USER 'travis'@'localhost' IDENTIFIED WITH mysql_native_password;";
-  - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost' WITH GRANT OPTION;";
   - psql -U postgres -c 'CREATE DATABASE yiitest;';
 script:
   # PHP tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ language: php
 env:
   global:
     - DEFAULT_COMPOSER_FLAGS="--prefer-dist --no-interaction --no-progress --optimize-autoloader"
-    - TASK_TESTS_PHP=1
-    - TASK_TESTS_COVERAGE=0
     - TRAVIS_SECOND_USER=travis_two
 
 
@@ -61,10 +59,8 @@ matrix:
   fast_finish: true
   include:
     - php: 7.2
-
     # run tests coverage on PHP 7.1
     - php: 7.1
-      env: TASK_TESTS_COVERAGE=1
     - php: nightly
       services:
         - mysql
@@ -73,21 +69,20 @@ matrix:
   allow_failures:
     - php: nightly
 
+before_install:
+  # Always remove xdebug.
+  - phpenv config-rm xdebug.ini || echo "xdebug is not installed"
 install:
-  - |
-    if [[ $TASK_TESTS_COVERAGE != 1 ]]; then
-      # disable xdebug for performance reasons when code coverage is not needed
-      phpenv config-rm xdebug.ini || echo "xdebug is not installed"
-    fi
-
   # install composer dependencies
   - travis_retry composer self-update
+  # Fast composer install
+  - travis_retry composer global require hirak/prestissimo
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install $DEFAULT_COMPOSER_FLAGS
 
   # setup PHP extension
   - |
-    if [[ $TASK_TESTS_PHP == 1 && $TRAVIS_PHP_VERSION != nightly ]]; then
+    if [[ $TRAVIS_PHP_VERSION != nightly ]]; then
       tests/data/travis/apcu-setup.sh
       tests/data/travis/memcache-setup.sh
       tests/data/travis/imagick-setup.sh
@@ -100,40 +95,18 @@ before_script:
   # show some versions and env information
   - php --version
   - composer --version
-  - |
-    if [ $TASK_TESTS_PHP == 1 ]; then
-      php -r "echo INTL_ICU_VERSION . \"\n\";"
-      php -r "echo INTL_ICU_DATA_VERSION . \"\n\";"
-      psql --version
-      mysql --version
-    fi
-
+  - php -r "echo INTL_ICU_VERSION . \"\n\";"
+  - php -r "echo INTL_ICU_DATA_VERSION . \"\n\";"
+  - psql --version
+  - mysql --version
   # initialize databases
-  - |
-    if [ $TASK_TESTS_PHP == 1 ]; then
-      travis_retry mysql -e 'CREATE DATABASE `yiitest`;';
-      mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';";
-      mysql -e "CREATE USER 'travis'@'localhost' IDENTIFIED WITH mysql_native_password;";
-      mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost' WITH GRANT OPTION;";
-      psql -U postgres -c 'CREATE DATABASE yiitest;';
-    fi
-
-  # enable code coverage
-  - |
-    if [ $TASK_TESTS_COVERAGE == 1 ]; then
-      PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
-    fi
-
+  - travis_retry mysql -e 'CREATE DATABASE `yiitest`;';
+  - mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';";
+  - mysql -e "CREATE USER 'travis'@'localhost' IDENTIFIED WITH mysql_native_password;";
+  - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost' WITH GRANT OPTION;";
+  - psql -U postgres -c 'CREATE DATABASE yiitest;';
 script:
   # PHP tests
-  - |
-    if [ $TASK_TESTS_PHP == 1 ]; then
-      vendor/bin/phpunit --verbose $PHPUNIT_FLAGS --exclude-group wincache,xcache
-    fi
-
+  - phpdbg -qrr vendor/bin/phpunit --verbose --coverage-clover=coverage.clover --exclude-group wincache,xcache
 after_script:
-  - |
-    if [ $TASK_TESTS_COVERAGE == 1 ]; then
-      travis_retry wget https://scrutinizer-ci.com/ocular.phar
-      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-    fi
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ before_script:
   - psql --version
   - mysql --version
   # initialize databases
+  - mysql_upgrade
   - travis_retry mysql -e 'CREATE DATABASE `yiitest`;';
   - mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';";
   - mysql -e "CREATE USER 'travis'@'localhost' IDENTIFIED WITH mysql_native_password;";

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ dist: trusty
 # temporary disable, see https://github.com/travis-ci/travis-ci/issues/6842
 #sudo: false
 sudo: required
-group: edge
 
 # build only on master branches
 # commented as this prevents people from running builds on their forks:


### PR DESCRIPTION
PHPDBG is much faster than xdebug.

This PR does several things:
- Always enable code coverage, so we can still get code coverage in case we have version specific code
- Use https://github.com/hirak/prestissimo to speed up composer install
- Remove unneeded conditions

Todo:
- Since now we're doing code coverage several times we should configure scrutinizer to wait for 3 submissions