### PR TITLE
Adjust to new DI and Reset response in mockWebApplication

### DIFF
--- a/src/base/Application.php
+++ b/src/base/Application.php
@@ -178,7 +178,7 @@ abstract class Application extends Module implements Initiable
 
     /**
      * Constructor.
-     * @param array $config name-value pairs that will be used to initialize the object properties.
+     * @param ContainerInterface $object that must contain both [[id]] and [[basePath]].
      * Note that the configuration must contain both [[id]] and [[basePath]].
      * @throws InvalidConfigException if either [[id]] or [[basePath]] configuration is missing.
      */

--- a/src/http/ResourceStream.php
+++ b/src/http/ResourceStream.php
@@ -37,13 +37,20 @@ class ResourceStream extends BaseObject implements StreamInterface
     /**
      * @var resource stream resource.
      */
-    public $resource;
+    private $resource;
 
     /**
      * @var array a resource metadata.
      */
     private $_metadata;
 
+    /**
+     * Constructor
+     */
+    public function __construct($resource)
+    {
+        $this->resource = $resource;
+    }
 
     /**
      * Destructor.
@@ -237,5 +244,10 @@ class ResourceStream extends BaseObject implements StreamInterface
         }
 
         return $this->_metadata[$key] ?? null;
+    }
+
+    public function getResource()
+    {
+        return $this->resource;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -99,6 +99,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 'scriptFile' => __DIR__ . '/index.php',
                 'scriptUrl' => '/index.php',
             ],
+            'response' => [
+                '__class' => \yii\web\Response::class,
+            ]
         ]);
         return $this->mockApplication($config, $appClass, $services);
     }

--- a/tests/framework/http/ResourceStreamTest.php
+++ b/tests/framework/http/ResourceStreamTest.php
@@ -200,6 +200,7 @@ class ResourceStreamTest extends TestCase
     {
         /* @var $stream ResourceStream|\PHPUnit_Framework_MockObject_MockObject */
         $stream = $this->getMockBuilder(ResourceStream::class)
+            ->setConstructorArgs([null])
             ->setMethods(['getMetadata'])
             ->getMock();
 
@@ -223,6 +224,7 @@ class ResourceStreamTest extends TestCase
     {
         /* @var $stream ResourceStream|\PHPUnit_Framework_MockObject_MockObject */
         $stream = $this->getMockBuilder(ResourceStream::class)
+            ->setConstructorArgs([null])
             ->setMethods(['getMetadata'])
             ->getMock();
 

--- a/tests/framework/http/ResourceStreamTest.php
+++ b/tests/framework/http/ResourceStreamTest.php
@@ -44,8 +44,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'read.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $this->assertTrue($stream->isReadable());
         $this->assertTrue($stream->isSeekable());
@@ -66,8 +65,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'seek.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $stream->seek(5);
         $this->assertSame('56789', $stream->read(5));
@@ -84,8 +82,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'get-content.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $this->assertSame('0123456789', $stream->getContents());
 
@@ -101,8 +98,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'to-string.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $this->assertSame('0123456789', (string)$stream);
 
@@ -117,8 +113,7 @@ class ResourceStreamTest extends TestCase
     {
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'write.txt';
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'wb+');
+        $stream = new ResourceStream(fopen($filename, 'wb+'));
 
         $this->assertTrue($stream->isWritable());
 
@@ -138,8 +133,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'get-size.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $this->assertSame(10, $stream->getSize());
 
@@ -155,8 +149,7 @@ class ResourceStreamTest extends TestCase
         $filename = $this->testFilePath . DIRECTORY_SEPARATOR . 'get-meta-data.txt';
         file_put_contents($filename, '0123456789');
 
-        $stream = new ResourceStream();
-        $stream->resource = fopen($filename, 'rb');
+        $stream = new ResourceStream(fopen($filename, 'rb'));
 
         $metadata = $stream->getMetadata();
 


### PR DESCRIPTION
Reset response when mockWebApplication: this is needed doing HttpCache tests, such as this: https://github.com/yiisoft/yii-web/blob/70018261b5892c74a0638b0d7dc79fe2c5a05089/tests/filters/HttpCacheTest.php#L87
Otherwise, when this test is launched (after the previous), response object is already filled.

I thought to a "replaceAll" method of Container, but it could bring more problems than solutions.