### PR TITLE
Also ignoring \n in expected and actual matching

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -139,8 +139,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function assertEqualsWithoutLE(string $expected, string $actual, string $message = ''): void
     {
-        $expected = str_replace("\r\n", "\n", $expected);
-        $actual = str_replace("\r\n", "\n", $actual);
+        $expected = str_replace(["\r\n", "\n"], ["\n", ""], $expected);
+        $actual = str_replace(["\r\n", "\n"], ["\n", ""], $actual);
 
         $this->assertEquals($expected, $actual, $message);
     }


### PR DESCRIPTION
Needed in XmlFormatterTest in yii-httpclient package, because matching string are missing final \n