### PR TITLE
BaseStringHelper::isEmpty() static method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework Change Log
 3.0.0 under development
 -----------------------
 
-- Enh #166: Added `BaseStringHelper::isEmpty()` method. Unlike `empty` function, returns TRUE when gets "0" string. (GHopperMKS)
+- Enh #166: Added `BaseStringHelper::isEmpty()` method. Unlike `empty` function, returns TRUE when gets "0" string (GHopperMKS)
 - Bug #145: Fixed `IpHelper::ip2bin()` to work properly on 32-bit architectures (samdark)
 - Chg #134: `StringHelper::truncate()` was renamed to `StringHelper::truncateCharacters()` (samdark)
 - Chg #134: Ability to truncate taking HTML into account was removed from `StringHelper` in favor of `HtmlPurifier` helper (samdark)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework Change Log
 3.0.0 under development
 -----------------------
 
+- Enh #166: Added `BaseStringHelper::isEmpty()` method. Unlike `empty` function, returns TRUE when gets "0" string. (GHopperMKS)
 - Bug #145: Fixed `IpHelper::ip2bin()` to work properly on 32-bit architectures (samdark)
 - Chg #134: `StringHelper::truncate()` was renamed to `StringHelper::truncateCharacters()` (samdark)
 - Chg #134: Ability to truncate taking HTML into account was removed from `StringHelper` in favor of `HtmlPurifier` helper (samdark)

--- a/src/helpers/BaseStringHelper.php
+++ b/src/helpers/BaseStringHelper.php
@@ -447,4 +447,21 @@ class BaseStringHelper
             : \htmlspecialchars($string, $flags, $encoding ?: ini_get('default_charset'), $double_encode)
         ;
     }
+
+    /**
+     * Check if a string is empty, relying on its length. Solves unobvious behavior when `empty('0')` equal to TRUE.
+     *
+     * @param string $string
+     * @param bool $trim
+     * @return bool
+     * @see http://php.net/empty
+     */
+    public static function isEmpty(string $string, $trim = true)
+    {
+        $string = (string) $string;
+        if ($trim) {
+            $string = \trim($string);
+        }
+        return strlen($string) === 0;
+    }
 }

--- a/tests/framework/helpers/StringHelperTest.php
+++ b/tests/framework/helpers/StringHelperTest.php
@@ -417,4 +417,11 @@ class StringHelperTest extends TestCase
     {
         $this->assertSame($expectedResult, StringHelper::mb_ucwords($string));
     }
+
+    public function testIsEmpty()
+    {
+        $this->assertFalse(StringHelper::isEmpty('0'));
+        $this->assertFalse(StringHelper::isEmpty('  ', false));
+        $this->assertTrue(StringHelper::isEmpty('  '));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #166 
